### PR TITLE
docs: update installation instructions to use @main

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Run multiple AI coding agents simultaneously without chaos. Each agent gets its 
 cd your-project
 
 # Bootstrap everything in one command
-uvx --no-cache --from git+https://github.com/Soul-Brews-Studio/multi-agent-workflow-kit.git@v0.2.6-alpha multi-agent-kit init
+uvx --no-cache --from git+https://github.com/Soul-Brews-Studio/multi-agent-workflow-kit.git@main multi-agent-kit init
 
 # Activate the environment
 source .envrc
@@ -184,14 +184,14 @@ Use: `maw start profile1`
 ### Using Specific Version
 
 ```bash
-# Use v0.2.6-alpha (latest features)
-uvx --no-cache --from git+https://github.com/Soul-Brews-Studio/multi-agent-workflow-kit.git@v0.2.6-alpha multi-agent-kit init
+# Use main branch (latest features)
+uvx --no-cache --from git+https://github.com/Soul-Brews-Studio/multi-agent-workflow-kit.git@main multi-agent-kit init
 
 # Or with custom prefix (creates: demo-ai-<repo-name>)
-uvx --no-cache --from git+https://github.com/Soul-Brews-Studio/multi-agent-workflow-kit.git@v0.2.6-alpha multi-agent-kit init --prefix demo
+uvx --no-cache --from git+https://github.com/Soul-Brews-Studio/multi-agent-workflow-kit.git@main multi-agent-kit init --prefix demo
 
 # Opt in to agents/.gitignore (defaults to not creating it)
-uvx --no-cache --from git+https://github.com/Soul-Brews-Studio/multi-agent-workflow-kit.git@v0.2.6-alpha multi-agent-kit init --agents-gitignore
+uvx --no-cache --from git+https://github.com/Soul-Brews-Studio/multi-agent-workflow-kit.git@main multi-agent-kit init --agents-gitignore
 ```
 
 ### Manual Installation


### PR DESCRIPTION
## Summary
- Updated all `uvx` installation commands in README.md to reference `@main` branch instead of `@v0.2.6-alpha`
- Changed comment text from "Use v0.2.6-alpha (latest features)" to "Use main branch (latest features)"

## Changes
This PR updates the installation instructions in two locations:
1. **Quick Start section** - Updated the bootstrap command
2. **Installation Options section** - Updated all three installation examples

## Rationale
Using `@main` ensures users always get the latest stable version without needing to update documentation for each release. This simplifies maintenance and ensures users don't inadvertently install an outdated version.

## Test plan
- [ ] Verify README displays correctly on GitHub
- [ ] Confirm all `uvx` commands reference `@main` branch
- [ ] Check that no other references to version tags remain in user-facing documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)