### PR TITLE
fix: Exclude maw-issue helper files from package distribution

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -4,3 +4,4 @@
 !commands/
 !commands/*
 commands/maw.*
+commands/maw-*

--- a/src/multi_agent_kit/assets/.claude/.gitignore
+++ b/src/multi_agent_kit/assets/.claude/.gitignore
@@ -3,7 +3,6 @@
 !commands/
 !commands/*
 commands/maw.*
+commands/maw-*
 !commands/maw.issue.md
 !commands/maw.issue.sh
-!commands/maw-issue.md
-!commands/maw-issue.sh

--- a/src/multi_agent_kit/assets/.claude/commands/maw-issue.md
+++ b/src/multi_agent_kit/assets/.claude/commands/maw-issue.md
@@ -1,4 +1,0 @@
-# /maw-issue — Alias
-
-`/maw-issue` is an alias for `/maw.issue`. Use either name to create a GitHub
-issue via the toolkit helper. See `/maw.issue` for full usage details.

--- a/src/multi_agent_kit/assets/.claude/commands/maw-issue.sh
+++ b/src/multi_agent_kit/assets/.claude/commands/maw-issue.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-# Wrapper to allow /maw-issue to reuse /maw.issue implementation
-
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-exec "$SCRIPT_DIR/maw.issue.sh" "$@"


### PR DESCRIPTION
Fixes #11

## Problem
When users run `uvx --from multi-agent-kit multi-agent-kit init --force-assets`, the `maw-issue.md` and `maw-issue.sh` files were being copied to their `.claude/commands/` directory. These are development/testing helper files that should NOT be distributed to end users.

## Solution
1. **Added ignore patterns** to `src/multi_agent_kit/assets/.claude/.gitignore`:
   - `commands/maw-*` - Ignores hyphenated maw files
   - Removed explicit un-ignore lines for maw-issue files

2. **Deleted files** from source assets:
   - Removed `maw-issue.md` and `maw-issue.sh` from `src/multi_agent_kit/assets/.claude/commands/`
   - Files remain in project root for local development use

3. **Untracked from git**:
   - Used `git rm --cached` to remove tracking while keeping local copies

## Testing
✅ `uv build` completes successfully  
✅ Package tarball excludes `maw-issue.*` files  
✅ Fresh `uvx init` does NOT copy `maw-issue.*` files  
✅ Gitignore patterns correctly ignore `maw-*` files  
✅ All production `maw.*` files (with dots) still distributed correctly  
✅ Upgrade scenario: Users with existing files will have them gitignored  

## What's Included vs Excluded

### ❌ Excluded (dev files):
- `maw-issue.md`
- `maw-issue.sh`

### ✅ Included (production files):
- `maw.agents-create.md`
- `maw.codex.md/sh`
- `maw.hey.md/sh`
- `maw.issue.md/sh` (with dot!)
- `maw.sync.md/sh`
- `maw.zoom.md/sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>