### PR TITLE
feat: Add 'maw zoom' command support

### DIFF
--- a/src/multi_agent_kit/assets/.agents/maw.completion.bash
+++ b/src/multi_agent_kit/assets/.agents/maw.completion.bash
@@ -5,7 +5,7 @@ _maw_complete() {
   local cur prev words cword
   _init_completion || return
 
-  local subcommands="attach agents catlab direnv help hey install kill remove send setup start uninstall version warp"
+  local subcommands="attach agents catlab direnv help hey install kill remove send setup start uninstall version warp zoom"
 
   if [[ $cword -eq 1 ]]; then
     # Complete main subcommands
@@ -34,6 +34,18 @@ _maw_complete() {
       # Complete agent names + "root"
       local agents_dir="${MAW_REPO_ROOT:-$PWD}/agents"
       local targets="root"
+      if [[ -d "$agents_dir" ]]; then
+        local agent_dirs
+        agent_dirs=$(ls -1 "$agents_dir" 2>/dev/null | grep -v '^\.')
+        targets="$targets $agent_dirs"
+      fi
+      COMPREPLY=($(compgen -W "$targets" -- "$cur"))
+      return 0
+      ;;
+    zoom)
+      # Complete agent names + "root" for zoom command
+      local agents_dir="${MAW_REPO_ROOT:-$PWD}/agents"
+      local targets="root --list"
       if [[ -d "$agents_dir" ]]; then
         local agent_dirs
         agent_dirs=$(ls -1 "$agents_dir" 2>/dev/null | grep -v '^\.')

--- a/src/multi_agent_kit/assets/.agents/maw.completion.zsh
+++ b/src/multi_agent_kit/assets/.agents/maw.completion.zsh
@@ -22,6 +22,7 @@ _maw() {
     'uninstall:Run uninstall.sh to remove toolkit assets'
     'version:Show toolkit version information'
     'warp:Navigate to agent worktree or root'
+    'zoom:Toggle zoom (maximize/restore) for a specific agent pane'
   )
 
   _arguments -C \
@@ -59,6 +60,29 @@ _maw() {
 
           # Add root option
           _wanted targets expl 'warp target' compadd -d '(Repository root directory)' root
+
+          # Add agent directories if they exist
+          if [[ -d "$agents_dir" ]]; then
+            agent_dirs=()
+            local dir
+            for dir in "$agents_dir"/*(N/); do
+              local basename="${dir:t}"
+              [[ "$basename" == .* ]] && continue
+              agent_dirs+=("$basename")
+            done
+
+            if [[ ${#agent_dirs[@]} -gt 0 ]]; then
+              _wanted agents expl 'agent worktree' compadd -a agent_dirs
+            fi
+          fi
+          ;;
+        zoom)
+          local agents_dir="${MAW_REPO_ROOT:-$PWD}/agents"
+          local -a agent_dirs
+
+          # Add special options
+          _wanted targets expl 'zoom target' compadd -d '(Repository root directory)' root
+          _wanted options expl 'zoom options' compadd --list
 
           # Add agent directories if they exist
           if [[ -d "$agents_dir" ]]; then

--- a/src/multi_agent_kit/assets/.agents/maw.env.sh
+++ b/src/multi_agent_kit/assets/.agents/maw.env.sh
@@ -50,6 +50,7 @@ Commands:
   uninstall          Run uninstall.sh to remove toolkit assets
   warp <target>      Navigate to agent worktree or root (e.g., warp 1, warp root)
   hey <agent> <msg>  Send a message to a specific agent (e.g., hey 1 analyse repo)
+  zoom <agent>       Toggle zoom (maximize/restore) for a specific agent pane
   direnv             Run 'direnv allow' in repo root and all agent worktrees
   catlab             Download CLAUDE.md guidelines from catlab gist
   version            Show toolkit version information
@@ -165,6 +166,9 @@ maw() {
     hey)
       __maw_exec hey.sh "$@"
       ;;
+    zoom)
+      __maw_exec zoom.sh "$@"
+      ;;
     direnv)
       __maw_exec direnv-allow.sh "$@"
       ;;
@@ -195,6 +199,7 @@ alias maw-remove='maw remove'
 alias maw-uninstall='maw uninstall'
 alias maw-hey='maw hey'
 alias maw-issue='maw issue'
+alias maw-zoom='maw zoom'
 
 # Load shell completion if available
 if [[ -n "${ZSH_VERSION:-}" ]]; then


### PR DESCRIPTION
Fixes #13

## Problem
The toolkit had a `zoom.sh` script and `/maw.zoom` Claude command, but users **could not use `maw zoom`** from the command line, creating an inconsistent user experience.

## Solution
Added `zoom` subcommand to the `maw` CLI function:

### Changes Made

**1. maw.env.sh** (`src/multi_agent_kit/assets/.agents/maw.env.sh`)
- ✅ Added `zoom <agent>` to usage documentation (line 53)
- ✅ Added `zoom)` case handler to execute `zoom.sh` (lines 169-171)
- ✅ Added `alias maw-zoom='maw zoom'` for consistency (line 202)

**2. Bash Completion** (`src/multi_agent_kit/assets/.agents/maw.completion.bash`)
- ✅ Added `zoom` to subcommands list (line 8)
- ✅ Added `zoom)` case with agent/root/--list completion (lines 45-56)

**3. Zsh Completion** (`src/multi_agent_kit/assets/.agents/maw.completion.zsh`)
- ✅ Added `zoom` to subcommands array with description (line 25)
- ✅ Added `zoom)` case with agent/root/--list completion (lines 79-101)

## Testing

✅ **Help documentation**:
```bash
$ maw help | grep zoom
  zoom <agent>       Toggle zoom (maximize/restore) for a specific agent pane
```

✅ **List agents**:
```bash
$ maw zoom --list
📋 Available agents:
  (agents directory not found)

Special targets:
  - root  (main worktree pane)
```

✅ **Alias works**:
```bash
$ type maw-zoom
maw-zoom is an alias for maw zoom
```

✅ **Shell completions** include `zoom` in both bash and zsh

✅ **Behavior matches** `/maw.zoom` Claude command

## Usage Examples

After installation:
```bash
# Zoom agent 1
maw zoom 1

# Zoom root pane
maw zoom root

# List available agents
maw zoom --list

# Using alias
maw-zoom 1
```

## Backward Compatibility

- ✅ All existing commands continue to work
- ✅ `/maw.zoom` Claude command unchanged
- ✅ `zoom.sh` script unchanged
- ✅ No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>